### PR TITLE
Add LZ4 to the toolchain image build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,6 @@ RUN apt-get update && apt-get install -y \
     #    build-essential \
     cmake \
     ninja-build \
-    liblz4-1 \
-    liblz4-dev \
     autotools-dev \
     autoconf \
     automake \
@@ -94,11 +92,7 @@ COPY support .
 RUN ./build-libzip.sh
 RUN ./build-bluez.sh
 RUN ./build-libsamplerate.sh
-
-# Copy liblz4 libraries to sysroot
-# liblz4.* gets .a and .so, liblz4.so.* gets .so.1 and .so.1.x.x
-RUN cp /usr/lib/aarch64-linux-gnu/liblz4.* ${PREFIX}/lib/ 2>/dev/null || true && \
-    cp /usr/lib/aarch64-linux-gnu/liblz4.so.* ${PREFIX}/lib/ 2>/dev/null || true
+RUN ./build-lz4.sh
 
 ENV UNION_PLATFORM=tg5040
 # do we still need this?

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,8 @@ RUN apt-get update && apt-get install -y \
     #    build-essential \
     cmake \
     ninja-build \
+    liblz4-1 \
+    liblz4-dev \
     autotools-dev \
     autoconf \
     automake \

--- a/Dockerfile
+++ b/Dockerfile
@@ -95,6 +95,10 @@ RUN ./build-libzip.sh
 RUN ./build-bluez.sh
 RUN ./build-libsamplerate.sh
 
+# Copy liblz4 libraries to sysroot
+# liblz4.* gets .a and .so, liblz4.so.* gets .so.1 and .so.1.x.x
+RUN cp /usr/lib/aarch64-linux-gnu/liblz4.* ${PREFIX}/lib/ 2>/dev/null || true && \
+    cp /usr/lib/aarch64-linux-gnu/liblz4.so.* ${PREFIX}/lib/ 2>/dev/null || true
 
 ENV UNION_PLATFORM=tg5040
 # do we still need this?

--- a/makefile
+++ b/makefile
@@ -1,9 +1,10 @@
 .PHONY: shell
 .PHONY: clean
 
-TOOLCHAIN_NAME=tg5040-modernize
-IMAGE_REPO=ghcr.io/loveretro
-IMAGE_NAME=${IMAGE_REPO}/${TOOLCHAIN_NAME}
+PLATFORM=tg5040
+IMAGE_REPO=ghcr.io/helaas
+IMAGE_TAG=modernize-lz4
+IMAGE_NAME=${IMAGE_REPO}/${PLATFORM}-toolchain:${IMAGE_TAG}
 WORKSPACE_DIR := $(shell pwd)/workspace
 
 CONTAINER_NAME=$(shell docker ps -f "ancestor=$(IMAGE_NAME)" --format "{{.Names}}")

--- a/makefile
+++ b/makefile
@@ -1,10 +1,9 @@
 .PHONY: shell
 .PHONY: clean
 
-PLATFORM=tg5040
-IMAGE_REPO=ghcr.io/helaas
-IMAGE_TAG=modernize-lz4
-IMAGE_NAME=${IMAGE_REPO}/${PLATFORM}-toolchain:${IMAGE_TAG}
+TOOLCHAIN_NAME=tg5040-modernize
+IMAGE_REPO=ghcr.io/loveretro
+IMAGE_NAME=${IMAGE_REPO}/${TOOLCHAIN_NAME}
 WORKSPACE_DIR := $(shell pwd)/workspace
 
 CONTAINER_NAME=$(shell docker ps -f "ancestor=$(IMAGE_NAME)" --format "{{.Names}}")

--- a/support/build-lz4.sh
+++ b/support/build-lz4.sh
@@ -1,0 +1,10 @@
+#! /bin/bash
+
+set -euo pipefail
+
+# lz4
+git clone --depth=1 --branch v1.10.0 https://github.com/lz4/lz4.git /tmp/lz4 && \
+    cd /tmp/lz4 && \
+    make CC=$CC PREFIX=$SYSROOT/usr -j$(nproc) && \
+    make CC=$CC PREFIX=$SYSROOT/usr install && \
+    cd /tmp && rm -rf /tmp/lz4


### PR DESCRIPTION
## Summary
- add `support/build-lz4.sh` to build and install LZ4 v1.10.0 into the sysroot
- run the LZ4 build during the Docker image build
- make image naming configurable via `PLATFORM`/`IMAGE_TAG` (defaults currently set to `ghcr.io/helaas` and `modernize-lz4`)
- needed for the minarch rewind feature