### PR TITLE
Dockerfile Clean Up

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -103,6 +103,6 @@ RUN mkdir -p ${PREFIX_LOCAL}/include
 RUN mkdir -p ${PREFIX_LOCAL}/lib
 
 VOLUME /root/workspace
-WORKDIR /workspace
+WORKDIR /root/workspace
 
 CMD ["/bin/bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,8 +23,6 @@ RUN apt-get update && apt-get install -y \
     vim \
     && rm -rf /var/lib/apt/lists/*
 
-COPY support /root/support
-
 ENV TOOLCHAIN_DIR=/opt/aarch64-nextui-linux-gnu
 
 # Download the appropriate cross toolchain based on host arch
@@ -88,11 +86,11 @@ ENV PKG_CONFIG_PATH=${SYSROOT}/usr/lib/pkgconfig:${SYSROOT}/usr/share/pkgconfig
 #ENV LDFLAGS="--sysroot=${SYSROOT} -L\"$SYSROOT/lib\" -L\"$SYSROOT/libc/usr/lib\""
 
 # stuff and extra libs
-COPY support .
-RUN ./build-libzip.sh
-RUN ./build-bluez.sh
-RUN ./build-libsamplerate.sh
-RUN ./build-lz4.sh
+COPY support /root/support
+RUN /root/support/build-libzip.sh
+RUN /root/support/build-bluez.sh
+RUN /root/support/build-libsamplerate.sh
+RUN /root/support/build-lz4.sh
 
 ENV UNION_PLATFORM=tg5040
 # do we still need this?

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:24.04
+FROM docker.io/library/ubuntu:24.04
 
 # Install base build tools and dependencies
 RUN apt-get update && apt-get install -y \

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,22 +38,15 @@ RUN mkdir -p ${TOOLCHAIN_DIR} && \
         echo "Unsupported architecture: $ARCH" && exit 1; \
     fi && \
     TOOLCHAIN_URL=${TOOLCHAIN_REPO}/releases/download/${TOOLCHAIN_BUILD}/${TOOLCHAIN_ARCHIVE}; \
-    wget -q $TOOLCHAIN_URL -O /tmp/toolchain.tar.xz && \
-    tar -xf /tmp/toolchain.tar.xz -C ${TOOLCHAIN_DIR} --strip-components=2 && \
-    rm /tmp/toolchain.tar.xz
+    wget -qO - $TOOLCHAIN_URL | tar -xJ -C ${TOOLCHAIN_DIR} --strip-components=2
 
 ENV CROSS_TRIPLE=aarch64-nextui-linux-gnu
 ENV CROSS_ROOT=${TOOLCHAIN_DIR}
 ENV SYSROOT=${CROSS_ROOT}/${CROSS_TRIPLE}/libc
 
 # Download and extract the SDK sysroot
-ENV SDK_TAR=SDK_usr_tg5040_a133p.tgz
-ENV SDK_URL=https://github.com/trimui/toolchain_sdk_smartpro/releases/download/20231018/${SDK_TAR}
-
-RUN mkdir -p ${SYSROOT} && \
-wget -q ${SDK_URL} -O /tmp/${SDK_TAR} && \
-tar -xzf /tmp/${SDK_TAR} -C ${SYSROOT} && \
-rm /tmp/${SDK_TAR}
+ARG SDK_URL=https://github.com/trimui/toolchain_sdk_smartpro/releases/download/20231018/SDK_usr_tg5040_a133p.tgz
+RUN mkdir -p ${SYSROOT} && wget -qO - ${SDK_URL} | tar -xzC ${SYSROOT}
 
 ENV AS=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-as \
     AR=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-ar \
@@ -73,8 +66,8 @@ ENV ARCH=arm64
 #ENV QEMU_SET_ENV="LD_LIBRARY_PATH=${CROSS_ROOT}/lib:${QEMU_LD_PREFIX}"
 
 # CMake toolchain
-COPY toolchain-aarch64.cmake ${CROSS_ROOT}/Toolchain.cmake
 ENV CMAKE_TOOLCHAIN_FILE=${CROSS_ROOT}/Toolchain.cmake
+COPY toolchain-aarch64.cmake ${CMAKE_TOOLCHAIN_FILE}
 
 #ENV PKG_CONFIG_PATH=/usr/lib/aarch64-linux-gnu/pkgconfig
 ENV PKG_CONFIG_SYSROOT_DIR=${SYSROOT}
@@ -97,10 +90,7 @@ ENV UNION_PLATFORM=tg5040
 ENV PREFIX_LOCAL=/opt/nextui
 
 # just to make sure
-RUN mkdir -p ${PREFIX_LOCAL}/include
-RUN mkdir -p ${PREFIX_LOCAL}/lib
+RUN mkdir -p ${PREFIX_LOCAL}/include ${PREFIX_LOCAL}/lib
 
 VOLUME /root/workspace
 WORKDIR /root/workspace
-
-CMD ["/bin/bash"]


### PR DESCRIPTION
I cleaned up some of the commands in the Dockerfile. There aren't any functional changes, but it is a little shorter and easier to read over.

Changes:

- Use full URI for Docker image to enable users to use `podman` more easily
- Fix working directory so users aren't confused why their project isn't in their current folder when they enter the container
- Remove first instance `COPY` of support files
- Shorten download and extract commands (`wget` + `tar`)
- Remove `CMD` because Ubuntu image already sets that

I kept my changes as separate commits in case you wanted to view them one at a time. I can squash them and push again if you prefer one commit.